### PR TITLE
Separando configuração do Xdebug em um novo Dockerfile para ambiente de desenvolvimento

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,25 +3,6 @@ FROM php:8.3-apache
 
 COPY ./ /var/www/html
 
-# instalando a extensão PHP Xdebug
-RUN pecl install xdebug && docker-php-ext-enable xdebug
-
-# Configurando o Xdebug
-RUN echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" >> /usr/local/etc/php/php.ini
-RUN echo "xdebug.mode=debug,develop" >> /usr/local/etc/php/php.ini
-RUN echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/php.ini
-RUN echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/php.ini
-RUN echo "xdebug.client_port=9003" >> /usr/local/etc/php/php.ini
-RUN echo "xdebug.log=/var/log/xdebug.log" >> /usr/local/etc/php/php.ini
-RUN echo "xdebug.log_level=7" >> /usr/local/etc/php/php.ini
-
-# Configurando o diretório para salvar os arquivos de perfil
-RUN mkdir -p /var/log/xdebug
-RUN echo "xdebug.output_dir=/var/log/xdebug" >> /usr/local/etc/php/php.ini
-RUN echo "xdebug.profiler_output_name=callgrind.out.%t" >> /usr/local/etc/php/php.ini
-RUN echo "xdebug.profiler_enable_trigger=1" >> /usr/local/etc/php/php.ini
-
-
 RUN service apache2 restart
 
 EXPOSE 80

--- a/src/Dockerfile.dev
+++ b/src/Dockerfile.dev
@@ -1,0 +1,27 @@
+# Dockerfile.tests
+FROM php:8.3-apache
+
+COPY ./ /var/www/html
+
+# instalando a extensão PHP Xdebug
+RUN pecl install xdebug && docker-php-ext-enable xdebug
+
+# Configurando o Xdebug
+RUN echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" >> /usr/local/etc/php/php.ini
+RUN echo "xdebug.mode=debug,develop" >> /usr/local/etc/php/php.ini
+RUN echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/php.ini
+RUN echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/php.ini
+RUN echo "xdebug.client_port=9003" >> /usr/local/etc/php/php.ini
+RUN echo "xdebug.log=/var/log/xdebug.log" >> /usr/local/etc/php/php.ini
+RUN echo "xdebug.log_level=7" >> /usr/local/etc/php/php.ini
+
+# Configurando o diretório para salvar os arquivos de perfil
+RUN mkdir -p /var/log/xdebug
+RUN echo "xdebug.output_dir=/var/log/xdebug" >> /usr/local/etc/php/php.ini
+RUN echo "xdebug.profiler_output_name=callgrind.out.%t" >> /usr/local/etc/php/php.ini
+RUN echo "xdebug.profiler_enable_trigger=1" >> /usr/local/etc/php/php.ini
+
+
+RUN service apache2 restart
+
+EXPOSE 80


### PR DESCRIPTION
Separando os dockerfiles para não haver extenções de dev em prod